### PR TITLE
Add cluster introspection

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -39,6 +39,7 @@ type JsonRpcRes struct {
 
 type NexusConn struct {
 	conn      net.Conn
+	proto     string
 	connRx    *smartio.SmartReader
 	connTx    *smartio.SmartWriter
 	connId    string
@@ -54,6 +55,7 @@ type NexusConn struct {
 func NewNexusConn(conn net.Conn) *NexusConn {
 	nc := &NexusConn{
 		conn:   conn,
+		proto:  "unknown",
 		connRx: smartio.NewSmartReader(conn),
 		connTx: smartio.NewSmartWriter(conn),
 		connId: nodeId + safeId(4),
@@ -307,6 +309,7 @@ func (nc *NexusConn) updateSession() {
 			"creationTime":  r.Row.Field("creationTime").Default(r.Now()),
 			"lastSeen":      r.Now(),
 			"remoteAddress": nc.conn.RemoteAddr().String(),
+			"protocol":      nc.proto,
 			"user":          nc.user.User,
 		}).
 		RunWrite(db)

--- a/connections.go
+++ b/connections.go
@@ -320,18 +320,6 @@ func (nc *NexusConn) updateSession() {
 	}
 }
 
-func (nc *NexusConn) deleteSession() {
-	res, err := r.Table("sessions").
-		Get(nc.connId).
-		Delete().
-		RunWrite(db)
-
-	if err != nil || res.Deleted != 1 {
-		log.Println("Error deregistering session", nc.connId, ":", err)
-		nc.close()
-	}
-}
-
 var numconn int64
 
 func (nc *NexusConn) handle() {
@@ -346,7 +334,6 @@ func (nc *NexusConn) handle() {
 	go nc.watchdog()
 
 	nc.updateSession()
-	defer nc.deleteSession()
 
 	for {
 		req, err := nc.pullReq()

--- a/connections.go
+++ b/connections.go
@@ -294,7 +294,13 @@ func (nc *NexusConn) close() {
 	}
 }
 
+var numconn int64
+
 func (nc *NexusConn) handle() {
+
+	atomic.AddInt64(&numconn, 1)
+	defer func() { atomic.AddInt64(&numconn, -1) }()
+
 	defer nc.close()
 	go nc.respWorker()
 	go nc.sendWorker()

--- a/connections.go
+++ b/connections.go
@@ -307,6 +307,7 @@ func (nc *NexusConn) updateSession() {
 			"creationTime":  r.Row.Field("creationTime").Default(r.Now()),
 			"lastSeen":      r.Now(),
 			"remoteAddress": nc.conn.RemoteAddr().String(),
+			"user":          nc.user.User,
 		}).
 		RunWrite(db)
 

--- a/database.go
+++ b/database.go
@@ -97,6 +97,22 @@ func dbBootstrap() error {
 			return err
 		}
 	}
+	cur, err = r.Table("sessions").IndexList().Run(db)
+	sessionsIndexList := make([]string, 0)
+	err = cur.All(&sessionsIndexList)
+	cur.Close()
+	if err != nil {
+		return err
+	}
+	if !inStrSlice(sessionsIndexList, "users") {
+		log.Println("Creating users index on tasks sessions")
+		_, err := r.Table("sessions").IndexCreateFunc("users", func(row r.Term) interface{} {
+			return row.Field("user")
+		}).RunWrite(db)
+		if err != nil {
+			return err
+		}
+	}
 	if !inStrSlice(tablelist, "nodes") {
 		log.Println("Creating nodes table")
 		_, err := r.TableCreate("nodes").RunWrite(db)

--- a/httplistener.go
+++ b/httplistener.go
@@ -36,7 +36,13 @@ func (*httpwsHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				}
 				log.Print("WebSocket connection from: ", ws.RemoteAddr())
 
-				NewNexusConn(ws).handle()
+				nc := NewNexusConn(ws)
+				if req.TLS != nil {
+					nc.proto = "wss"
+				} else {
+					nc.proto = "ws"
+				}
+				nc.handle()
 			}
 			if wsrv.Header == nil {
 				wsrv.Header = make(map[string][]string)
@@ -56,6 +62,11 @@ func (*httpwsHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		netCli, netSrv := net.Pipe()
 		netCliBuf := bufio.NewReader(netCli)
 		ns := NewNexusConn(netSrv)
+		if req.TLS != nil {
+			ns.proto = "https"
+		} else {
+			ns.proto = "http"
+		}
 		defer ns.close()
 		defer netCli.Close()
 		go ns.handle()

--- a/sys.go
+++ b/sys.go
@@ -125,10 +125,10 @@ func (nc *NexusConn) handleSysReq(req *JsonRpcReq) {
 		cur, err := r.Table("sessions").
 			Between(prefix, prefix+"\uffff", r.BetweenOpts{Index: "users"}).
 			Group("user").
-			Count().
+			Pluck("id", "nodeId", "remoteAddress", "creationTime").
 			Ungroup().
 			Map(func(row r.Term) interface{} {
-				return ei.M{"user": row.Field("group"), "sessions": row.Field("reduction")}
+				return ei.M{"user": row.Field("group"), "sessions": row.Field("reduction"), "n": row.Field("reduction").Count()}
 			}).Run(db)
 		if err != nil {
 			req.Error(ErrInternal, err.Error(), nil)

--- a/sys.go
+++ b/sys.go
@@ -99,6 +99,39 @@ func (nc *NexusConn) handleSysReq(req *JsonRpcReq) {
 			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&nc.user)), unsafe.Pointer(sud))
 		}
 		req.Result(ei.M{"ok": true, "user": nc.user.User})
+
+	case "sys.stats":
+		prefix, err := ei.N(req.Params).M("prefix").String()
+		if err != nil {
+			req.Error(ErrInvalidParams, "prefix", nil)
+			return
+		}
+		tags := nc.getTags(prefix)
+		if !(ei.N(tags).M("@admin").BoolZ()) {
+			req.Error(ErrPermissionDenied, "", nil)
+			return
+		}
+		cur, err := r.Table("tasks").Pluck("path").Run(db)
+		if err != nil {
+			req.Error(ErrInternal, "", nil)
+			return
+		}
+		pulls := make(map[string]int)
+		pushs := make(map[string]int)
+		var task Task
+		for cur.Next(&task) {
+			if strings.HasPrefix(task.Path, "@pull."+prefix) {
+				p := strings.TrimPrefix(task.Path, "@pull.")
+				pulls[p]++
+			} else if strings.HasPrefix(task.Path, prefix) {
+				pushs[task.Path]++
+			}
+		}
+		ret := make(map[string]interface{})
+		ret["pulls"] = pulls
+		ret["pushes"] = pushs
+		req.Result(ret)
+
 	default:
 		req.Error(ErrMethodNotFound, "", nil)
 	}

--- a/sys.go
+++ b/sys.go
@@ -126,7 +126,7 @@ func (nc *NexusConn) handleSysReq(req *JsonRpcReq) {
 		cur, err := r.Table("sessions").
 			Between(prefix, prefix+"\uffff", r.BetweenOpts{Index: "users"}).
 			Group("user").
-			Pluck("id", "nodeId", "remoteAddress", "creationTime").
+			Pluck("id", "nodeId", "remoteAddress", "creationTime", "protocol").
 			Ungroup().
 			Map(func(row r.Term) interface{} {
 				return ei.M{"user": row.Field("group"), "sessions": row.Field("reduction"), "n": row.Field("reduction").Count()}

--- a/sys.go
+++ b/sys.go
@@ -101,12 +101,11 @@ func (nc *NexusConn) handleSysReq(req *JsonRpcReq) {
 		nc.updateSession()
 		req.Result(ei.M{"ok": true, "user": nc.user.User})
 	case "sys.nodes":
-		tags := nc.getTags("")
-		if !(ei.N(tags).M("@admin").BoolZ()) {
+		tags := nc.getTags("sys.nodes")
+		if !(ei.N(tags).M("@sys.nodes").BoolZ() || ei.N(tags).M("@admin").BoolZ()) {
 			req.Error(ErrPermissionDenied, "", nil)
 			return
 		}
-
 		cur, err := r.Table("nodes").Pluck("id", "clients", "load").Run(db)
 		if err != nil {
 			req.Error(ErrInternal, "", nil)
@@ -119,7 +118,7 @@ func (nc *NexusConn) handleSysReq(req *JsonRpcReq) {
 		prefix := ei.N(req.Params).M("prefix").StringZ()
 
 		tags := nc.getTags(prefix)
-		if !(ei.N(tags).M("@session.list").BoolZ() || ei.N(tags).M("@admin").BoolZ()) {
+		if !(ei.N(tags).M("@sys.sessions").BoolZ() || ei.N(tags).M("@admin").BoolZ()) {
 			req.Error(ErrPermissionDenied, "", nil)
 			return
 		}

--- a/sys.go
+++ b/sys.go
@@ -98,6 +98,7 @@ func (nc *NexusConn) handleSysReq(req *JsonRpcReq) {
 			}
 			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&nc.user)), unsafe.Pointer(sud))
 		}
+		nc.updateSession()
 		req.Result(ei.M{"ok": true, "user": nc.user.User})
 	case "sys.nodes":
 		tags := nc.getTags("")

--- a/sys.go
+++ b/sys.go
@@ -132,6 +132,21 @@ func (nc *NexusConn) handleSysReq(req *JsonRpcReq) {
 		ret["pushes"] = pushs
 		req.Result(ret)
 
+	case "sys.nodes":
+		tags := nc.getTags("")
+		if !(ei.N(tags).M("@admin").BoolZ()) {
+			req.Error(ErrPermissionDenied, "", nil)
+			return
+		}
+		cur, err := r.Table("nodes").Pluck("id", "clients", "load").Run(db)
+		if err != nil {
+			req.Error(ErrInternal, "", nil)
+			return
+		}
+		var all []interface{}
+		cur.All(&all)
+		req.Result(all)
+
 	default:
 		req.Error(ErrMethodNotFound, "", nil)
 	}

--- a/tasks.go
+++ b/tasks.go
@@ -363,7 +363,7 @@ func (nc *NexusConn) handleTaskReq(req *JsonRpcReq) {
 			req.Error(ErrInvalidTask, "", nil)
 		}
 
-	case "task.stats":
+	case "task.list":
 		prefix, err := ei.N(req.Params).M("prefix").String()
 		if err != nil {
 			req.Error(ErrInvalidParams, "prefix", nil)

--- a/tasks.go
+++ b/tasks.go
@@ -370,7 +370,7 @@ func (nc *NexusConn) handleTaskReq(req *JsonRpcReq) {
 			return
 		}
 		tags := nc.getTags(prefix)
-		if !(ei.N(tags).M("@task.stats").BoolZ() || ei.N(tags).M("@admin").BoolZ()) {
+		if !(ei.N(tags).M("@task.list").BoolZ() || ei.N(tags).M("@admin").BoolZ()) {
 			req.Error(ErrPermissionDenied, "", nil)
 			return
 		}

--- a/tcplistener.go
+++ b/tcplistener.go
@@ -34,7 +34,9 @@ func tcpListener(u *url.URL) {
 			return
 		}
 		log.Print("TCP connection from:", conn.RemoteAddr())
-		go NewNexusConn(conn).handle()
+		nc := NewNexusConn(conn)
+		nc.proto = "tcp"
+		go nc.handle()
 	}
 }
 
@@ -74,6 +76,8 @@ func sslListener(u *url.URL) {
 			return
 		}
 		log.Println("SSL connection from:", conn.RemoteAddr())
-		go NewNexusConn(conn).handle()
+		nc := NewNexusConn(conn)
+		nc.proto = "ssl"
+		go nc.handle()
 	}
 }

--- a/users.go
+++ b/users.go
@@ -164,6 +164,27 @@ func (nc *NexusConn) handleUserReq(req *JsonRpcReq) {
 			return
 		}
 		req.Result(map[string]interface{}{"ok": true})
+	case "user.list":
+		prefix := ei.N(req.Params).M("prefix").StringZ()
+
+		tags := nc.getTags(prefix)
+		if !(ei.N(tags).M("@user.list").BoolZ() || ei.N(tags).M("@admin").BoolZ()) {
+			req.Error(ErrPermissionDenied, "", nil)
+			return
+		}
+		cur, err := r.Table("users").
+			Between(prefix, prefix+"\uffff").
+			Pluck("id", "tags").
+			Map(func(row r.Term) interface{} {
+				return ei.M{"user": row.Field("id"), "tags": row.Field("tags").Default(ei.M{})}
+			}).Run(db)
+		if err != nil {
+			req.Error(ErrInternal, err.Error(), nil)
+			return
+		}
+		var all []interface{}
+		cur.All(&all)
+		req.Result(all)
 	default:
 		req.Error(ErrMethodNotFound, "", nil)
 	}


### PR DESCRIPTION
- Added sys.nodes to query the cluster for nodes state (clients connected/cpu load)
- Added sys.sessions to query the cluster for active clients information
- Added task.list to retrieve the active push/pulls on a path
- Added user.list to retrieve the existent users which username starts with a prefix, and list their tags 
- Closes #9 
