### PR TITLE
Tag `@profile:user` at a prefix expands to the tags of that user/prefix

### DIFF
--- a/sys.go
+++ b/sys.go
@@ -127,7 +127,36 @@ func loadUserData(user string) (*UserData, int) {
 		}
 		return nil, ErrInternal
 	}
+
+	expandTags(ud)
+
 	return ud, ErrNoError
+}
+
+func expandTags(ud *UserData) {
+	for prefix, tags := range ud.Tags {
+		for tag, val := range tags {
+			if tag != "@profile" {
+				continue
+			}
+
+			sval, ok := val.(string)
+			if !ok {
+				continue
+			}
+
+			fromUser, err := loadUserData(sval)
+			if err != ErrNoError {
+				continue
+			}
+
+			for etag, eval := range getTags(fromUser, prefix) {
+				if _, ok := tags[etag]; !ok {
+					tags[etag] = eval
+				}
+			}
+		}
+	}
 }
 
 func (nc *NexusConn) BasicAuth(params interface{}) (string, map[string]map[string]interface{}, int) {


### PR DESCRIPTION
This is a proposal for fixing #8 

A tag `@profile:user` on a prefix, causes the tag to expand to every effective tag that the user from the tag has in that prefix.

If a tag comes from an expansion but there is already another tag set explicitly on the prefix, the latter prevails 

I cant find any security issue with this method, because the only one who can grant permissions on an user for a prefix, is an admin of that prefix which already could do that, and the only tags added are those related to the prefix being administered.

---

Example:

If the stored tags are

| User | Prefix | Tag |
| --- | --- | --- |
| root | `.` | `@admin:true` |
| foo | `bar` | `testTag:123` |
| unpriv | `test` | `@profile:root` |
| unpriv | `bar` | `testTag:987`, `@profile:foo` |

When the user _unpriv_ gets loaded and expanded, it becomes:

| User | Prefix | Tag |
| --- | --- | --- |
| unpriv | `test` | `@profile:root`, `@admin:true` |
| unpriv | `bar` | `testTag:987`, `@profile:foo` |

---

Do we keep the `@profile:user` syntax? This limits an user to being able to inherit tags from _one_ user only. Is this what we want?
