### PR TITLE
User rename

### DIFF
--- a/database.go
+++ b/database.go
@@ -92,6 +92,22 @@ func dbBootstrap() error {
 		}
 
 	}
+	cur, err = r.Table("users").IndexList().Run(db)
+	usersIndexList := make([]string, 0)
+	err = cur.All(&usersIndexList)
+	cur.Close()
+	if err != nil {
+		return err
+	}
+	if !inStrSlice(usersIndexList, "blockedBy") {
+		Log.Println("Creating blockedBy index on users sessions")
+		_, err := r.Table("users").IndexCreateFunc("blockedBy", func(row r.Term) interface{} {
+			return row.Field("blockedBy")
+		}).RunWrite(db)
+		if err != nil {
+			return err
+		}
+	}
 	if !inStrSlice(tablelist, "sessions") {
 		Log.Println("Creating sessions table")
 		_, err := r.TableCreate("sessions").RunWrite(db)

--- a/nodes.go
+++ b/nodes.go
@@ -142,6 +142,7 @@ func nodeTrack() {
 
 							masterCtx, masterCancel = context.WithCancel(context.Background())
 							go searchOrphaned(masterCtx)
+							go searchUncompleted(masterCtx)
 						}
 					} else {
 						if isMasterNode() {

--- a/nodes.go
+++ b/nodes.go
@@ -6,10 +6,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/jaracil/ei"
 	. "github.com/jaracil/nexus/log"
 	"github.com/shirou/gopsutil/load"
+	"github.com/sirupsen/logrus"
 	r "gopkg.in/gorethink/gorethink.v3"
 )
 
@@ -260,6 +260,80 @@ func searchOrphanedStuff(regex, what, field string) {
 					"error": err,
 					what:    s,
 				}).Errorln("Error deleting orphaned %s", what)
+			}
+		}
+	}
+}
+
+func searchUncompleted(ctx context.Context) {
+	t := time.After(time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-t:
+			t = time.After(time.Minute)
+			searchUncompletedRenames()
+		}
+	}
+}
+
+func searchUncompletedRenames() {
+	cur, err := r.Table("users").Between("", "\uffff", r.BetweenOpts{Index: "blockedBy"}).Run(db)
+	if err != nil {
+		if err != nil {
+			Log.WithFields(logrus.Fields{
+				"error": err,
+			}).Errorf("Error searching uncompleted user renames")
+			return
+		}
+	}
+	uncompleted := make([]interface{}, 0)
+	err = cur.All(&uncompleted)
+	cur.Close()
+
+	switch err {
+	default:
+		Log.WithFields(logrus.Fields{
+			"error": err,
+		}).Errorf("Error searching uncompleted user renames")
+
+	case r.ErrEmptyResult:
+
+	case nil:
+		if len(uncompleted) <= 0 {
+			return
+		}
+
+		for _, u := range uncompleted {
+			user := ei.N(u).M("id").StringZ()
+			blockedBy := ei.N(u).M("blockedBy").StringZ()
+			renaming := ei.N(u).M("renaming").StringZ()
+			if user != "" && blockedBy != "" {
+				cur, err = r.Table("sessions").Get(blockedBy).Run(db)
+				if err != nil {
+					Log.WithFields(logrus.Fields{
+						"error": err,
+					}).Errorf("Error searching uncompleted user rename session for %s", user)
+					cur.Close()
+					continue
+				}
+				if cur.IsNil() {
+					if renaming == "me" {
+						r.Table("users").Get(user).Delete().RunWrite(db)
+					} else {
+						if renaming != "" {
+							_, err = r.Table("users").Get(renaming).Delete().RunWrite(db)
+							if err != nil {
+								cur.Close()
+								continue
+							}
+						}
+						r.Table("users").Get(user).Replace(func(t r.Term) r.Term { return t.Without("blockedBy", "renaming") })
+					}
+				}
+				cur.Close()
 			}
 		}
 	}


### PR DESCRIPTION
To prevent users in an unconsistent state due to a failed rename in some step the following aproach can be used:

- Marking the "old" and "new" users as being in a rename operation by the session that issues the rename.
- If the rename fails in some step, try the best to return the users to their state before the rename operation.
- If some user is left in an unconsistent state a cleaning routine grabs users marked with a dead session and tries to return them to their state before the rename operation.